### PR TITLE
fix(kafka): add type header config to user-service producer

### DIFF
--- a/user-service.yml
+++ b/user-service.yml
@@ -3,8 +3,9 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
-
   kafka:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true


### PR DESCRIPTION
Added spring.json.add.type.headers=true to producer properties so Kafka message headers carry type information for correct deserialization on the consumer side.