### PR TITLE
chore(email): remove kafka configurations and isolate mail properties

### DIFF
--- a/email-service.yml
+++ b/email-service.yml
@@ -1,14 +1,4 @@
 spring:
-  kafka:
-    consumer:
-      group-id: email-service-group
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "com.miniedu.model.kafka.events"
-        spring.json.use.type.headers: true
-
   mail:
     properties:
       mail:


### PR DESCRIPTION
- Strip out redundant spring.kafka consumer configuration blocks
- Retain only the core legacy SMTP connection and timeout properties